### PR TITLE
use T to allow kriging on data that is not Float64

### DIFF
--- a/src/ordinary_kriging.jl
+++ b/src/ordinary_kriging.jl
@@ -67,7 +67,7 @@ function weights{T<:Real,V}(estimator::OrdinaryKriging{T,V}, xₒ::AbstractVecto
   nobs = length(z)
 
   # evaluate covariance at location
-  c = Float64[cov(norm(X[:,j]-xₒ)) for j=1:nobs]
+  c = T[cov(norm(X[:,j]-xₒ)) for j=1:nobs]
 
   # solve linear system
   b = [c; 1]

--- a/src/simple_kriging.jl
+++ b/src/simple_kriging.jl
@@ -66,7 +66,7 @@ function weights{T<:Real,V}(estimator::SimpleKriging{T,V}, xₒ::AbstractVector{
   nobs = length(z)
 
   # evaluate covariance at location
-  c = Float64[cov(norm(X[:,j]-xₒ)) for j=1:nobs]
+  c = T[cov(norm(X[:,j]-xₒ)) for j=1:nobs]
 
   # solve linear system
   y = z - μ

--- a/src/universal_kriging.jl
+++ b/src/universal_kriging.jl
@@ -83,11 +83,11 @@ function weights{T<:Real,V}(estimator::UniversalKriging{T,V}, xₒ::AbstractVect
   nobs = length(z)
 
   # evaluate variogram at location
-  g = Float64[γ(norm(X[:,j]-xₒ)) for j=1:nobs]
+  g = T[γ(norm(X[:,j]-xₒ)) for j=1:nobs]
 
   # evaluate multinomial at location
   nterms = size(exponents, 2)
-  f = Float64[prod(xₒ.^exponents[:,j]) for j=1:nterms]
+  f = T[prod(xₒ.^exponents[:,j]) for j=1:nterms]
 
   # solve linear system
   b = [g; f]


### PR DESCRIPTION
I was trying to perform kriging on `Float32` input data, but ran into `MethodError`s because [here](https://github.com/juliohm/GeoStats.jl/blob/04311dfa82/src/ordinary_kriging.jl#L70) the type is set to `Float64`, and because of this it will not be able to enter [here](https://github.com/juliohm/GeoStats.jl/blob/04311dfa82/src/ordinary_kriging.jl#L93) since not all `T` are the same type.

I know about the dangers of reduced floating point precision, but the rest of the code seems to be set up in a way that should allow this.

[Here](https://gist.github.com/visr/1822e7f0d96fd66c46fd944ace4c7f68) is a Gist that shows it generates approximately the same results. I could add this separately as a test.


