### PR TITLE
Create .gitattributes to fix GitHub Languages

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# LaTeX Stuff
+*.bib text
+*.tex text
+paper/* text
+
+# Documentations
+docs/* text


### PR DESCRIPTION
This is a Julia Package and if you take a look at the repository at GitHub it shows as a TeX main repository:
![image](https://user-images.githubusercontent.com/43353831/138337411-e8939c88-1eaa-41df-80f8-b63515bda5f2.png)

This PR creates a `.gitattributes` file that marks `.bib` and `.tex` files as text and all documentation inside the `docs/` folder as text.